### PR TITLE
Skipreadings

### DIFF
--- a/_sources/AdvancedAccumulation/Exercises.rst
+++ b/_sources/AdvancedAccumulation/Exercises.rst
@@ -6,6 +6,8 @@
     the license is included in the section entitled "GNU Free Documentation
     License".
 
+:skipreading:`True`
+
 .. qnum::
    :prefix: AdAccum-6-
    :start: 1 

--- a/_sources/AdvancedFunctions/Exercises.rst
+++ b/_sources/AdvancedFunctions/Exercises.rst
@@ -7,6 +7,8 @@
     the license is included in the section entitled "GNU Free Documentation
     License".
 
+:skipreading:`True`
+
 .. qnum::
    :prefix: advfuncs-4-
    :start: 1

--- a/_sources/Classes/Exercises.rst
+++ b/_sources/Classes/Exercises.rst
@@ -7,6 +7,8 @@
     the license is included in the section entitled "GNU Free Documentation
     License".
 
+:skipreading:`True`
+
 Exercises
 ---------
 

--- a/_sources/Conditionals/Exercises.rst
+++ b/_sources/Conditionals/Exercises.rst
@@ -6,6 +6,8 @@
     Contributor List, no Front-Cover Texts, and no Back-Cover Texts.  A copy of
     the license is included in the section entitled "GNU Free Documentation
     License".
+    
+:skipreading:`True`
 
 .. qnum::
    :prefix: condition-14-

--- a/_sources/Dictionaries/Exercises.rst
+++ b/_sources/Dictionaries/Exercises.rst
@@ -7,6 +7,8 @@
     the license is included in the section entitled "GNU Free Documentation
     License".
 
+:skipreading:`True`
+
 .. qnum::
    :prefix: dictionaries-8-
    :start: 1

--- a/_sources/Exceptions/Exercises.rst
+++ b/_sources/Exceptions/Exercises.rst
@@ -7,6 +7,8 @@
     the license is included in the section entitled "GNU Free Documentation
     License".
 
+:skipreading:`True`
+
 Exercises
 =========
 

--- a/_sources/Files/Exercises.rst
+++ b/_sources/Files/Exercises.rst
@@ -7,6 +7,8 @@
     the license is included in the section entitled "GNU Free Documentation
     License".
 
+:skipreading:`True`
+
 .. qnum::
    :prefix: files-9-
    :start: 1

--- a/_sources/Functions/Exercises.rst
+++ b/_sources/Functions/Exercises.rst
@@ -7,6 +7,8 @@
     the license is included in the section entitled "GNU Free Documentation
     License".
 
+:skipreading:`True`
+
 .. qnum::
    :prefix: func-14-
    :start: 1

--- a/_sources/GeneralIntro/Exercises.rst
+++ b/_sources/GeneralIntro/Exercises.rst
@@ -7,6 +7,8 @@
     the license is included in the section entitled "GNU Free Documentation
     License".
 
+:skipreading:`True`
+
 .. qnum::
    :prefix: intro-12-
    :start: 1

--- a/_sources/Inheritance/Exercises.rst
+++ b/_sources/Inheritance/Exercises.rst
@@ -6,6 +6,7 @@
     the license is included in the section entitled "GNU Free Documentation
     License".
 
+:skipreading:`True`
 
 Exercises
 =========

--- a/_sources/Iteration/Exercises.rst
+++ b/_sources/Iteration/Exercises.rst
@@ -7,6 +7,8 @@
     the license is included in the section entitled "GNU Free Documentation
     License".
 
+:skipreading:`True`
+
 .. qnum::
    :prefix: iter-11-
    :start: 1

--- a/_sources/Iteration/NestedIterationImageProcessing.rst
+++ b/_sources/Iteration/NestedIterationImageProcessing.rst
@@ -61,8 +61,9 @@ no basic color. On the other hand, "White" has maximum values for all three basi
 	 =======  =======  =======  =======
 
 In order to manipulate an image, we need to be able to access individual pixels. This capability is provided by a module 
-called **image**, provided in ActiveCode. See :ref:`image-processing-on-own` for ways to deal with images in standard 
-Python. The image module defines two classes: ``Image`` and ``Pixel``.
+called **image**, provided in ActiveCode [1]_.  The image module defines two classes: ``Image`` and ``Pixel``.
+
+.. [1] If you want to explore image processing on your own outside of the browser you can install the cImage module from http://pypi.org.
 
 Each Pixel object has three attributes: the red intensity, the green intensity, and the blue intensity. A pixel provides 
 three methods that allow us to ask for the intensity values. They are called ``getRed``, ``getGreen``, and ``getBlue``.  

--- a/_sources/MoreAboutIteration/Exercises.rst
+++ b/_sources/MoreAboutIteration/Exercises.rst
@@ -7,6 +7,8 @@
     the license is included in the section entitled "GNU Free Documentation
     License".
 
+:skipreading:`True`
+
 .. qnum::
    :prefix: moreiter-9-
    :start: 1

--- a/_sources/NestedData/Exercises.rst
+++ b/_sources/NestedData/Exercises.rst
@@ -7,6 +7,8 @@
     the license is included in the section entitled "GNU Free Documentation
     License".
 
+:skipreading:`True`
+
 .. qnum::
    :prefix: nested-5-
    :start: 1

--- a/_sources/PythonModules/Exercises.rst
+++ b/_sources/PythonModules/Exercises.rst
@@ -7,6 +7,8 @@
     the license is included in the section entitled "GNU Free Documentation
     License".
 
+:skipreading:`True`
+
 .. qnum::
    :prefix: modules-5-
    :start: 1

--- a/_sources/PythonTurtle/Exercises.rst
+++ b/_sources/PythonTurtle/Exercises.rst
@@ -7,6 +7,8 @@
     the license is included in the section entitled "GNU Free Documentation
     License".
 
+:skipreading:`True`
+
 .. qnum::
    :prefix: turtle-10-
    :start: 1

--- a/_sources/Sequences/Exercises.rst
+++ b/_sources/Sequences/Exercises.rst
@@ -7,6 +7,8 @@
     the license is included in the section entitled "GNU Free Documentation
     License".
 
+:skipreading:`True`
+
 .. qnum::
    :prefix: seq-11-
    :start: 1

--- a/_sources/Sorting/Exercises.rst
+++ b/_sources/Sorting/Exercises.rst
@@ -7,6 +7,8 @@
     the license is included in the section entitled "GNU Free Documentation
     License".
 
+:skipreading:`True`
+
 .. qnum::
    :prefix: sort-8-
    :start: 1

--- a/_sources/TransformingSequences/Exercises.rst
+++ b/_sources/TransformingSequences/Exercises.rst
@@ -7,6 +7,8 @@
     the license is included in the section entitled "GNU Free Documentation
     License".
 
+:skipreading:`True`
+
 .. qnum::
    :prefix: seqmut-13-
    :start: 1

--- a/pavement.py
+++ b/pavement.py
@@ -2,7 +2,7 @@ import paver
 from paver.easy import *
 import paver.setuputils
 paver.setuputils.install_distutils_tasks()
-import os, sys
+import os, sys, socket
 from runestone.server import get_dburl
 from sphinxcontrib import paverutils
 import pkg_resources
@@ -10,8 +10,14 @@ import pkg_resources
 sys.path.append(os.getcwd())
 
 home_dir = os.getcwd()
-master_url = 'http://127.0.0.1:8000'
-master_url = 'https://fopp.learningpython.today/'
+hostname = socket.gethostname()
+if hostname in ['runestone-deploy', 'rsbuilder', 'runestone.academy']:
+    master_url = 'https://runestone.academy'
+elif hostname == 'fopp.learningpython.today':
+    master_url = 'https://fopp.learningpython.today'
+else:
+    master_url = 'http://127.0.0.1:8000'
+
 master_app = 'runestone'
 serving_dir = "./build/fopp"
 dest = "../../static"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-runestone>=3.0.0
+runestone>=3.2.0
 SQLAlchemy>=1.0.8


### PR DESCRIPTION
Use the 

```
:skipreading:`True`
``` 

role to keep Exercises out of the readings picker

requirements.txt is also updated to indicate that runestone 3.2 or higher is required for the new role.