### PR TITLE
add variables to control aspects of the book and layout

### DIFF
--- a/_templates/plugin_layouts/sphinx_bootstrap/layout.html
+++ b/_templates/plugin_layouts/sphinx_bootstrap/layout.html
@@ -298,8 +298,11 @@
 <footer class="footer">
   <div class="container">
     <p class="pull-right">
+      {% if lockdown != 'True' -%}
+        <span id='numuserspan'></span> readers online now |
+      {%- endif -%}
       {% if use_services == 'true' %}
-      <span id='numuserspan'></span> readers online now | <span class='loggedinuser'></span>
+      <span class='loggedinuser'></span>
       {% endif %}
       | <a href="#">Back to top</a>
       {% if theme_source_link_position == "footer" %}

--- a/_templates/plugin_layouts/sphinx_bootstrap/layout.html
+++ b/_templates/plugin_layouts/sphinx_bootstrap/layout.html
@@ -38,6 +38,7 @@
 {% macro navBar() %}
 
 <!-- Begin navbar -->
+
 <div id="navbar" class="navbar navbar-default navbar-fixed-top" role="navigation">
 
   <div class="container">
@@ -62,9 +63,11 @@
       <ul class="nav navbar-nav navbar-right" >
 
         <li class="divider-vertical"></li>
-
         <!-- social media dropdown -->
+       {% if lockdown != 'True' -%}
+
         <li class="dropdown">
+
           <a class="dropdown-toggle" href="#" data-toggle="dropdown">
             <i class="glyphicon glyphicon-globe" style="opacity: 0.9"><span aria-label="Social"></span></i>
           </a>
@@ -93,8 +96,11 @@
 
                 </div>
               </li>
+
           </ul>
+
         </li>
+          {%- endif -%}
         <!-- end social media dropdown -->
 
         <li class="divider-vertical"></li>
@@ -143,19 +149,27 @@
             <li class="divider"></li>
             <li><a href='{{course_url}}/{{appname}}/assignments/practice'>Practice</a></li>
             <li class="divider"></li>
+               {% if lockdown != 'True' -%}
             <li><a href='/{{appname}}/default/courses'>Change Course</a></li>
-            <li class="divider"></li>
-            <li><a href='{{course_url}}/{{appname}}/mygroup/initiateGroup' id="joinGroupLink">Join a Study Group</a></li>
-            <li><a href='{{course_url}}/{{appname}}/mygroup/schedule' id="groupScheduleLink">Group Schedule</a></li>
-            <li><a href='{{course_url}}/{{appname}}/mygroup/newschedule' id="newChapterLink">Schedule New Chapter</a></li>
-            <li><a href='{{course_url}}/{{appname}}/mygroup/manageGroup' id="manageGroupLink">Manage Group</a></li>
+               {%- endif -%}
+            {% if lockdown != 'True' -%}
+                <li class="divider"></li>
+                <li><a href='{{course_url}}/{{appname}}/mygroup/initiateGroup' id="joinGroupLink">Join a Study Group</a></li>
+                <li><a href='{{course_url}}/{{appname}}/mygroup/schedule' id="groupScheduleLink">Group Schedule</a></li>
+                <li><a href='{{course_url}}/{{appname}}/mygroup/newschedule' id="newChapterLink">Schedule New Chapter</a></li>
+                <li><a href='{{course_url}}/{{appname}}/mygroup/manageGroup' id="manageGroupLink">Manage Group</a></li>
+              {%- endif -%}
 			<li class="divider"></li>
-            <li><a href='{{course_url}}/{{appname}}/admin/index'>Instructor's Page</a></li>
+              {% if lockdown != 'True' -%}
+                <li><a href='{{course_url}}/{{appname}}/admin/index'>Instructor's Page</a></li>
+              {%- endif -%}
             <li><a href='{{ course_url }}/{{ appname }}/assignments/index'>Progress Page</a></li>
             <li class="divider"></li>
-            <li><a href="{{course_url}}/{{appname}}/default/user/profile" id="profilelink">Edit Profile</a></li>
-            <li><a href="{{course_url}}/{{appname}}/default/user/change_password" id="passwordlink">Change Password</a></li>
-            <li><a href="{{course_url}}/{{appname}}/default/user/register" id="registerlink">Register</a></li>
+              {% if lockdown != 'True' -%}
+                <li><a href="{{course_url}}/{{appname}}/default/user/profile" id="profilelink">Edit Profile</a></li>
+                <li><a href="{{course_url}}/{{appname}}/default/user/change_password" id="passwordlink">Change Password</a></li>
+                <li><a href="{{course_url}}/{{appname}}/default/user/register" id="registerlink">Register</a></li>
+              {%- endif -%}
             <li class='loginout'><a href='#'>Login</a></li> <!-- correct link populated by addNavbarLoginLink() -->
           </ul>
         </li>
@@ -244,7 +258,7 @@
   eBookConfig.downloadsEnabled = {{downloads_enabled}};
   eBookConfig.enable_chatcodes = {{enable_chatcodes}} ? {{ enable_chatcodes }} : false;
 </script>
-
+{% if lockdown != 'True' -%}
 <div id="fb-root"></div>
 <script>
   (function(d, s, id) {
@@ -255,6 +269,7 @@
     fjs.parentNode.insertBefore(js, fjs);
   }(document, 'script', 'facebook-jssdk'));
 </script>
+{% endif %}
 
 {% endblock %}
 
@@ -314,7 +329,7 @@
 {% if appname == "runestone" %}
 <script type="text/javascript">
   var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', 'UA-32029811-1']);
+  _gaq.push(['_setAccount', '{{ google_ga_account }}']);
   _gaq.push(['_trackPageview']);
 
   (function() {
@@ -323,7 +338,10 @@
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
 </script>
+
+{% if lockdown != 'True' -%}
 <script async src="https://hypothes.is/embed.js"></script>
+{% endif %}
 
 {% endif %}
 

--- a/_templates/plugin_layouts/sphinx_bootstrap/layout.html
+++ b/_templates/plugin_layouts/sphinx_bootstrap/layout.html
@@ -185,6 +185,8 @@
 
         <li class="divider-vertical"></li>
 
+
+       {% if lockdown != 'True' -%}
         <!-- help menu dropdown -->
         <li class="dropdown">
           <a class="dropdown-toggle" href="#" data-toggle="dropdown">
@@ -201,7 +203,7 @@
         <!-- end help menu dropdown -->
 
         <li class="divider-vertical"></li>
-
+       {%- endif -%}
       </ul>
 
       <ul class="nav navbar-nav">

--- a/pavement.py
+++ b/pavement.py
@@ -18,9 +18,13 @@ elif hostname == 'fopp.learningpython.today':
 else:
     master_url = 'http://127.0.0.1:8000'
 
+
+master_url = ''
 master_app = 'runestone'
 serving_dir = "./build/fopp"
 dest = "../../static"
+
+
 
 options(
     sphinx = Bunch(docroot=".",),
@@ -44,9 +48,11 @@ options(
                        'jobe_server': 'http://jobe2.cosc.canterbury.ac.nz',
                        'proxy_uri_runs': '/jobe/index.php/restapi/runs/',
                        'proxy_uri_files': '/jobe/index.php/restapi/files/',
-                       'downloads_enabled': 'false',
-                       'enable_chatcodes': 'false'
-                        }
+                       'downloads_enabled': 'true',
+                       'enable_chatcodes': 'false',
+                       'google_ga_account': 'UA-21213626-9',
+                       'lockdown': "True"
+                     }
     )
 )
 


### PR DESCRIPTION
### Description 
This add 2 vars to pavement.py
lockdown will remove all social and items that are not required for Michigan. 
 google_ga_account will allow you to provide a GA account code via pavement. This is set to the Michigan one at the moment. 

I have also set the master_url to '', which should force the book to use relative URLS. 


### Testing

Compile the book and validate the items that are gone should be gone, and that there are no side effects from the master_url change. 