### PR TITLE
[FIX]: make activecode section 8, 4.4.4, actual active code

### DIFF
--- a/_sources/Conditionals/Theinandnotinoperators.rst
+++ b/_sources/Conditionals/Theinandnotinoperators.rst
@@ -42,7 +42,7 @@ The ``not in`` operator returns the logical opposite result of ``in``.
 
 We can also use the ``in`` and ``not in`` operators on lists!
 
-..activecode:: ac4_4_4
+.. activecode:: ac4_4_4
 
    print("a" in ["a", "b", "c", "d"])
    print(9 in [3, 2, 9, 10, 9.0])


### PR DESCRIPTION
Adding a missing space to the activecode section ac4_4_4 in Section 8 to fix it into actual active code.