### PR TITLE
FIX: section 9, asign_c01_02; Make acronym that is tested against an …

### DIFF
--- a/_sources/TransformingSequences/week4a1.rst
+++ b/_sources/TransformingSequences/week4a1.rst
@@ -738,7 +738,7 @@ Chapter Assessment - Problem Solving
    :practice: T
    :topics: TransformingSequences/TheAccumulatorPatternwithStrings
 
-   Write code that uses the string stored in ``sent`` and creates an acronym which is assigned to the variable ``acro``. The first two letters of each word should be used, each letter in the acronym should be a capital letter, and each element of the acronym should be separated by a ". ". Words that should not be included in the acronym are stored in the list ``stopwords``. For example, if ``sent`` was assigned the string "height and ewok wonder" then the resulting acronym should be "HE. EW. WO".
+   Write code that uses the string stored in ``sent`` and creates an acronym which is assigned to the variable ``acro``. The first two letters of each word should be used, each letter in the acronym should be a capital letter, and each element of the acronym should be separated by a ". " (dot and space). Words that should not be included in the acronym are stored in the list ``stopwords``. For example, if ``sent`` was assigned the string "height and ewok wonder" then the resulting acronym should be "HE. EW. WO".
    ~~~~
    stopwords = ['to', 'a', 'for', 'by', 'an', 'am', 'the', 'so', 'it', 'and', 'The']
    sent = "The water earth and air are vital"


### PR DESCRIPTION
…acronym without spaces.

I suggest that either the exercise should be reworded into " The first two letters of each word should be used, each letter in the acronym should be a capital letter, and each element of the acronym should be separated by a “.  “ (dot and space)", or that the proposed change to the test condition is made.

Upon rereading the task just after submitting this PR I actually realized that the example provided contains spaces (For example, if sent was assigned the string “height and ewok wonder” then the resulting acronym should be “HE. EW. WO”.), but I have to admit I did only spot this after rereading a couple of times... I'm not sure whether the task is supposed to be inflicting such a high amount of "Whoops I did not spot this in the exercise"-errors (nor whether it might be only me having attentional deficits ;-) )... happy to discuss this.