### PR TITLE
ENH: introduce term antipattern to glossary of Iteration

### DIFF
--- a/_sources/Iteration/Glossary.rst
+++ b/_sources/Iteration/Glossary.rst
@@ -36,6 +36,12 @@ Glossary
         becoming a mature programmer is to learn and establish the
         patterns and algorithms that form your toolkit.   
 
+    antipattern
+	    A an ineffective or suboptimal pattern, which while being not
+		incorrect provides suboptimal implementation which is either
+		slower, less expressive, or over-complicated than the better solution
+		could potentially be.
+
     index
         A variable or value used to select a member of an ordered collection, such as
         a character from a string, or an element from a list.


### PR DESCRIPTION
Iteration section is a good place to introduce it.  A typical antipattern is

```python
for idx in range(len(items)):
      do_something(items[idx])
```
instead of a simpler and more expressive
```python
for item in iterable:
      do_something(item)
```
yet to reference that in the text, first wanted to check.

Also I would have liked to add a reference to wikipedia -- https://en.wikipedia.org/wiki/Anti-pattern