### PR TITLE
Running ac18_5_3 Results in Incorrectly Sorted List

### DIFF
--- a/_sources/Sorting/SecondarySortOrder.rst
+++ b/_sources/Sorting/SecondarySortOrder.rst
@@ -61,7 +61,7 @@ One solution is to add a negative sign in front of ``len(fruit_name)``, which wi
 .. activecode:: ac18_5_3
 
     fruits = ['peach', 'kiwi', 'apple', 'blueberry', 'papaya', 'mango', 'pear']
-    new_order = sorted(fruits, key=lambda fruit_name: (-len(fruit_name), fruit_name), reverse=True)
+    new_order = sorted(fruits, key=lambda fruit_name: (-len(fruit_name), fruit_name))
     for fruit in new_order:
         print(fruit)
    


### PR DESCRIPTION
---
name: Running ac18_5_3 Results in Incorrectly Sorted List
about: The list that is printed when running ac18_5_3 is not sorted as described in the preceding text.

---

**Describe the bug**
The text that precedes the ActiveCode window describes using a '-' in front of the len function so that the longest elements are first and the shortest are last.  However, this only works if the optional reverse=True parameter is removed or changed to False.

**To Reproduce**
Steps to reproduce the behavior:
1. Go to 'Sorting/SecondarySortOrder.html'
2. Scroll down to the ActiveCode: 4 section.
3. Click "Save & Run".
4. Observe that the printed results are sorted shortest to longest.

**Expected behavior**
When "Save & Run" is clicked, the printed list should be sorted from longest to shortest with alphabetical secondary sorting.