### PR TITLE
Unit Test for ac18_3_4 Passes Even When Sorted Incorrectly

### DIFF
--- a/_sources/Sorting/Optionalkeyparameter.rst
+++ b/_sources/Sorting/Optionalkeyparameter.rst
@@ -126,6 +126,7 @@ value to the sorted function. Inside the sorted function, whose code we haven't 
 
       def testOne(self):
          self.assertEqual(func_sort, ['dance', 'zebra', 'hi', 'how are you', 'apple', 'bye'], "Testing that func_sort has the correct value.")
+         self.assertIn("key", self.getEditorText(), "Testing your code (Don't worry about actual and expected values).")
          self.assertNotIn("lambda", self.getEditorText(), "Testing your code (Don't worry about actual and expected values).")
 
    myTests().main()

--- a/_sources/Sorting/Optionalkeyparameter.rst
+++ b/_sources/Sorting/Optionalkeyparameter.rst
@@ -125,7 +125,7 @@ value to the sorted function. Inside the sorted function, whose code we haven't 
    class myTests(TestCaseGui):
 
       def testOne(self):
-         self.assertEqual(func_sort, sorted(ex_lst, key = second_let), "Testing that func_sort has the correct value.")
+         self.assertEqual(func_sort, ['dance', 'zebra', 'hi', 'how are you', 'apple', 'bye'], "Testing that func_sort has the correct value.")
          self.assertNotIn("lambda", self.getEditorText(), "Testing your code (Don't worry about actual and expected values).")
 
    myTests().main()


### PR DESCRIPTION
---
name: Unit Test for ac18_3_4 Passes Even When Sorted Incorrectly
about: The ac18_3_4 value unit test doesn't actually check sorting.

---

**Describe the bug**
The unit test that checks the value of func_sort relies on the student's
second_let function and compares the results to itself. Regardless of how
the list is sorted, the test succeeds.

**To Reproduce**
Steps to reproduce the behavior:
1. Go to 'Sorting/Optionalkeyparameter.html'
2. Scroll down to ActiveCode: 4 (ac18_3_4)
3. Add: def second_let(x):
            return x[0]
4. Add: func_sort = sorted(ex_lst, key=second_let)
5. Click 'Run'
6. Observe that all tests pass even though func_sort is sorted by the first
   letter in each string rather than the second
7. Change the return parameter of second_let to x[1]
8. Observe that tests continue to succeed when func_sort is sorted properly

**Expected behavior**
The value unit test for func_sort should compare results to a hard-coded list
rather than comparing it to the results of the second_let function.  Another 
unit test should also be added to check that the key parameter is used.

**Desktop:**
 - OS: MacOS 10.14.3
 - Browser: chrome
 - Version: 71.0.3578.98
