### PR TITLE
Fix README.rst to reference fopp

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ We have tried to make it as easy as possible for you to build and use this book.
 1.  You can build it and host it yourself in just a few simple steps:
 
     1.  ``pip install -r requirements.txt``  -- Should install everything you need
-    2.  ``runestone build`` -- will build the html and put it in ``./build/thinkcspy``
-    3.  ``runestone serve``   -- will start a webserver and serve the pages locally from ``./build/thinkcspy``
+    2.  ``runestone build`` -- will build the html and put it in ``./build/fopp``
+    3.  ``runestone serve``   -- will start a webserver and serve the pages locally from ``./build/fopp``
 
 


### PR DESCRIPTION
---
name: Fix README.rst to Reference FOPP
about: The README states that html is built and put in ./build/thinkcspy
       but it should read ./build/fopp instead.

---

**Describe the bug**
The README references ./build/thinkcspy as the build directory.

**Expected behavior**
The README should reference ./build/fopp as the build directory.

**Desktop:**
 - OS: MacOS 10.14.3
 - Browser: chrome
 - Version: 71.0.3578.98