### PR TITLE
Making tests for CYU exercise clearer (and added a test for second_let)

### DIFF
--- a/_sources/Sorting/Optionalkeyparameter.rst
+++ b/_sources/Sorting/Optionalkeyparameter.rst
@@ -126,7 +126,8 @@ value to the sorted function. Inside the sorted function, whose code we haven't 
 
       def testOne(self):
          self.assertEqual(func_sort, sorted(ex_lst, key = second_let), "Testing that func_sort has the correct value.")
-         self.assertNotIn("lambda", self.getEditorText(), "Testing your code (Don't worry about actual and expected values).")
+         self.assertEqual(second_let('0123456789'), '1', "Testing that the second_let function returns the second letter in a string.")
+         self.assertNotIn("lambda", self.getEditorText(), "Checking that you did *not* use a lambda (Don't worry about actual and expected values).")
 
    myTests().main()
 


### PR DESCRIPTION
Please use this PR instead of https://github.com/RunestoneInteractive/fopp/pull/204