### PR TITLE
Fixed minor typo in ac18_4_6

### DIFF
--- a/_sources/Sorting/SortingaDictionary.rst
+++ b/_sources/Sorting/SortingaDictionary.rst
@@ -91,7 +91,7 @@ Here's a version of that using a named function.
     
     # now loop through the keys
     for k in y:
-        print("{} appears {} times".format(x, d[x]))
+        print("{} appears {} times".format(k, d[k]))
 
 .. note::
 


### PR DESCRIPTION
`x` and `d[x]` should be `k` and `d[k]`