### PR TITLE
Don't allow codelens on file examples

### DIFF
--- a/_sources/Files/AlternativeFileReadingMethods.rst
+++ b/_sources/Files/AlternativeFileReadingMethods.rst
@@ -15,11 +15,11 @@ Alternative File Reading Methods
 --------------------------------
 
 Once you have a file "object", the thing returned by the open function, Python provides three methods to read data
-from that object. The ``read()`` method returns the entire contents of the file as a single string (or just some 
+from that object. The ``read()`` method returns the entire contents of the file as a single string (or just some
 characters if you provide a number as an input parameter. The ``readlines`` method returns the entire contents of
-the entire file as a list of strings, where each item in the list is one line of the file. The ``readline`` 
-method reads one line from the file and returns it as a string. The strings returned by ``readlines`` or 
-``readline`` will contain the newline character at the end.  :ref:`Table 2 <filemethods2a>` summarizes these 
+the entire file as a list of strings, where each item in the list is one line of the file. The ``readline``
+method reads one line from the file and returns it as a string. The strings returned by ``readlines`` or
+``readline`` will contain the newline character at the end.  :ref:`Table 2 <filemethods2a>` summarizes these
 methods and the following session shows them in action.
 
 .. _filemethods2a:
@@ -49,17 +49,17 @@ methods and the following session shows them in action.
 ======================== =========================== =====================================
 
 
-In this course, we will generally either iterate through the lines returned by ``readlines()`` with a for loop, 
+In this course, we will generally either iterate through the lines returned by ``readlines()`` with a for loop,
 or use ``read()`` to get all of the contents as a single string.
 
-In other programming languages, where they don't have the convenient for loop method of going through the lines 
-of the file one by one, they use a different pattern which requires a different kind of loop, the ``while`` loop. 
-Fortunately, you don't need to learn this other pattern, and we will put off consideration of ``while`` loops 
+In other programming languages, where they don't have the convenient for loop method of going through the lines
+of the file one by one, they use a different pattern which requires a different kind of loop, the ``while`` loop.
+Fortunately, you don't need to learn this other pattern, and we will put off consideration of ``while`` loops
 until later in this course. We don't need them for handling data from files.
 
 .. note::
 
-   A common error that novice programmers make is not realizing that all these ways of reading the file contents, 
+   A common error that novice programmers make is not realizing that all these ways of reading the file contents,
    **use up the file**. After you call readlines(), if you call it again you'll get an empty list.
 
 **Check your Understanding**
@@ -78,10 +78,11 @@ until later in this course. We don't need them for handling data from files.
     writing at some point in their academic career, be it essays, research papers,
     technical write ups, or scripts.
     </pre>
- 
+
 
 .. activecode:: ac9_4_1
    :language: python
+   :nocodelens:
    :autograde: unittest
    :practice: T
    :available_files: school_prompt2.txt
@@ -112,7 +113,7 @@ until later in this course. We don't need them for handling data from files.
     France: Paris, Nice, Lyon
     Spain: Madrid, Barcelona, Granada
     Austria: Vienna
-    I will probably not even want to come back! 
+    I will probably not even want to come back!
     However, I wonder how I will get by with all the different languages.
     I only know English!
     </pre>
@@ -120,12 +121,13 @@ until later in this course. We don't need them for handling data from files.
 .. activecode:: ac9_4_2
    :available_files: travel_plans2.txt
    :language: python
+   :nocodelens:
    :autograde: unittest
    :practice: T
 
    2. Find the number of lines in the file, ``travel_plans2.txt``, and assign it to the variable ``num_lines``.
    ~~~~
-   
+
    =====
 
    from unittest.gui import TestCaseGui
@@ -153,10 +155,11 @@ until later in this course. We don't need them for handling data from files.
 .. activecode:: ac9_4_3
    :available_files: emotion_words2.txt
    :language: python
+   :nocodelens:
    :autograde: unittest
    :practice: T
-   
-   3. Create a string called ``first_forty`` that is comprised of the first 40 characters of ``emotion_words2.txt``. 
+
+   3. Create a string called ``first_forty`` that is comprised of the first 40 characters of ``emotion_words2.txt``.
    ~~~~
 
    =====
@@ -167,7 +170,7 @@ until later in this course. We don't need them for handling data from files.
 
       def testOne(self):
          self.assertEqual(first_forty, 'Sad upset blue down melancholy somber bi', "Testing that first_forty was created correctly.")
-   myTests().main() 
+   myTests().main()
 
 .. datafile:: travel_plans2.txt
    :fromfile: travel_plans.txt

--- a/_sources/Files/Iteratingoverlinesinafile.rst
+++ b/_sources/Files/Iteratingoverlinesinafile.rst
@@ -14,16 +14,16 @@
 Iterating over lines in a file
 ------------------------------
 
-We will now use this file as input in a program that will do some data processing. In the program, we will 
-examine each line of the file and print it with some additional text. Because ``readlines()`` returns a list of 
+We will now use this file as input in a program that will do some data processing. In the program, we will
+examine each line of the file and print it with some additional text. Because ``readlines()`` returns a list of
 lines of text, we can use the *for* loop to iterate through each line of the file.
 
-A **line** of a file is defined to be a sequence of characters up to and including a special character called 
-the **newline** character. If you evaluate a string that contains a newline character you will see the character 
-represented as ``\n``. If you print a string that contains a newline you will not see the ``\n``, you will just 
+A **line** of a file is defined to be a sequence of characters up to and including a special character called
+the **newline** character. If you evaluate a string that contains a newline character you will see the character
+represented as ``\n``. If you print a string that contains a newline you will not see the ``\n``, you will just
 see its effects (a carriage return).
 
-As the *for* loop iterates through each line of the file the loop variable will contain the current line of the 
+As the *for* loop iterates through each line of the file the loop variable will contain the current line of the
 file as a string of characters. The general pattern for processing each line of a text file is as follows:
 
 ::
@@ -39,6 +39,7 @@ athlete. We can then take the values corresponding to name, team and event to
 construct a simple sentence.
 
 .. activecode:: ac9_5_1
+   :nocodelens:
 
     olypmicsfile = open("olypmics.txt","r")
 
@@ -48,12 +49,13 @@ construct a simple sentence.
 
     olypmicsfile.close()
 
-To make the code a little simpler, and to allow for more efficient processing, Python provides a built-in way to 
-iterate through the contents of a file one line at a time, without first reading them all into a list. Some students find this confusing initially, so we don't recommend doing it this way, until you get a 
-little more comfortable with Python. But this idiom is preferred by Python programmers, so you should be prepared 
+To make the code a little simpler, and to allow for more efficient processing, Python provides a built-in way to
+iterate through the contents of a file one line at a time, without first reading them all into a list. Some students find this confusing initially, so we don't recommend doing it this way, until you get a
+little more comfortable with Python. But this idiom is preferred by Python programmers, so you should be prepared
 to read it. And when you start dealing with big files, you may notice the efficiency gains of using it.
 
 .. activecode:: ac9_5_2
+   :nocodelens:
 
     olypmicsfile = open("olypmics.txt","r")
 
@@ -110,6 +112,7 @@ to read it. And when you start dealing with big files, you may notice the effici
 .. activecode:: ac9_5_3
    :available_files: emotion_words.txt
    :language: python
+   :nocodelens:
    :autograde: unittest
    :practice: T
 
@@ -126,4 +129,4 @@ to read it. And when you start dealing with big files, you may notice the effici
          self.assertEqual(num_lines, 7, "Testing that num_lines was assigned to the correct value.")
          self.assertNotIn('len', self.getEditorText(), "Testing your code (Don't worry about actual and expected values).")
 
-   myTests().main() 
+   myTests().main()

--- a/_sources/Files/ReadingCSVFiles.rst
+++ b/_sources/Files/ReadingCSVFiles.rst
@@ -17,12 +17,13 @@ Reading in data from a CSV File
 We are able to read in CSV files the same way we have with other text files. Because of the standardized structure of the data, there is a common pattern for processing it. To practice this,
 we will be using data about olympic events.
 
-Typically, CSV files will have a header as the first line, which contains column names. Then, 
-each following row in the file will contain data that corresponds to the appropriate columns. 
+Typically, CSV files will have a header as the first line, which contains column names. Then,
+each following row in the file will contain data that corresponds to the appropriate columns.
 
 All file methods that we have mentioned - ``read``, ``readline``, and ``readlines``, and simply iterating over the file object itself - will work on CSV files. In our examples, we will iterate over the lines. Because the values on each line are separated with commas, we can use the ``.split()`` method to parse each line into a collection of separate value.
 
 .. activecode:: ac9_13_1
+   :nocodelens:
 
     fileconnection = open("olympics.txt", 'r')
     lines = fileconnection.readlines()

--- a/_sources/Files/ReadingaFile.rst
+++ b/_sources/Files/ReadingaFile.rst
@@ -25,6 +25,7 @@ use ``fileref`` will result in an error.
 
 .. activecode:: ac9_2_1
     :available_files: olympics.txt
+    :nocodelens:
 
     fileref = open("olympics.txt","r")
     ## other code here that refers to variable fileref

--- a/_sources/Files/WritingCSVFiles.rst
+++ b/_sources/Files/WritingCSVFiles.rst
@@ -15,11 +15,12 @@
 Writing data to a CSV File
 ==========================
 
-The typical pattern for writing data to a CSV file will be to write a header row and loop 
-through the items in a list, outputting one row for 
+The typical pattern for writing data to a CSV file will be to write a header row and loop
+through the items in a list, outputting one row for
 each. Here we a have a list of tuples, each representing one Olympian, a subset of the rows and columns from the file we have been reading from.
 
 .. activecode:: ac9_14_1
+   :nocodelens:
 
    olympians = [("John Aalberg", 31, "Cross Country Skiing"),
                ("Minna Maarit Aalto", 30, "Sailing"),
@@ -36,7 +37,7 @@ each. Here we a have a list of tuples, each representing one Olympian, a subset 
        outfile.write(row_string)
        outfile.write('\n')
    outfile.close()
-   
+
 There are a few things worth noting in the code above.
 
 First, using .format() makes it really clear what we're doing when we create the variable row_string. We are making a comma separated set of values; the {} curly braces indicated where to substitute in the actual values. The equivalent string concatenation would be very hard to read. An alternative, also clear way to do it would be with the .join method: ``row_string = ','.join(olympian[0], olympian[1], olympian[2])``.
@@ -45,11 +46,11 @@ Second, unlike the print statement, remember that the .write() method on a file 
 
 Third, we have to explicitly refer to each of the elements of olympian when building the string to write. Note that just putting ``.format(olympian)`` wouldn't work because the interpreter would see only one value (a tuple) when it was expecting three values to try to substitute into the string template. Later in the book we will see that python provides an advanced technique for automatically unpacking the three values from the tuple, with ``.format(*olympian)``.
 
-As described previously, if one or more columns contain text, and that text could contain commas, we need to do something 
-to distinguish a comma in the text from a comma that is separating different values (cells in the 
-table). If we want to enclose each value in double quotes, it can start to get a little tricky, because we will 
-need to have the double quote character inside the string output. But it is doable. Indeed, one 
-reason Python allows strings to be delimited with either single quotes or double quotes is so 
+As described previously, if one or more columns contain text, and that text could contain commas, we need to do something
+to distinguish a comma in the text from a comma that is separating different values (cells in the
+table). If we want to enclose each value in double quotes, it can start to get a little tricky, because we will
+need to have the double quote character inside the string output. But it is doable. Indeed, one
+reason Python allows strings to be delimited with either single quotes or double quotes is so
 that one can be used to delimit the string and the other can be a character in the string. If you get to the point where you need to quote all of the values, we recommend learning to use python's csv module.
 
 .. activecode:: ac9_14_2

--- a/_sources/Files/WritingTextFiles.rst
+++ b/_sources/Files/WritingTextFiles.rst
@@ -14,31 +14,31 @@
 Writing Text Files
 ------------------
 
-One of the most commonly performed data processing tasks is to read data from a file, 
-manipulate it in some way, and then write the resulting data out to a new data file to be used 
-for other purposes later. To accomplish this, the ``open`` function discussed above can also be 
-used to create a new file prepared for writing. Note in :ref:`Table 1<filemethods1a>` 
-that the only difference between opening a file for writing and opening a file for reading is 
-the use of the ``'w'`` flag instead of the ``'r'`` flag as the second parameter. When we open 
-a file for writing, a new, empty file with that name is created and made ready to accept our 
+One of the most commonly performed data processing tasks is to read data from a file,
+manipulate it in some way, and then write the resulting data out to a new data file to be used
+for other purposes later. To accomplish this, the ``open`` function discussed above can also be
+used to create a new file prepared for writing. Note in :ref:`Table 1<filemethods1a>`
+that the only difference between opening a file for writing and opening a file for reading is
+the use of the ``'w'`` flag instead of the ``'r'`` flag as the second parameter. When we open
+a file for writing, a new, empty file with that name is created and made ready to accept our
 data. If an existing file has the same name, its contents are overwritten. As before, the function returns a reference to the new file object.
 
-:ref:`Table 2 <filemethods2a>` shows one additional method on file objects that we have not used 
-thus far. The ``write`` method allows us to add data to a text file. Recall that text files 
-contain sequences of characters. We usually think of these character sequences as being the 
-lines of the file where each line ends with the newline ``\n`` character. Be very careful to 
-notice that the ``write`` method takes one parameter, a string. When invoked, the characters of 
-the string will be added to the end of the file. This means that it is the programmer's job to 
+:ref:`Table 2 <filemethods2a>` shows one additional method on file objects that we have not used
+thus far. The ``write`` method allows us to add data to a text file. Recall that text files
+contain sequences of characters. We usually think of these character sequences as being the
+lines of the file where each line ends with the newline ``\n`` character. Be very careful to
+notice that the ``write`` method takes one parameter, a string. When invoked, the characters of
+the string will be added to the end of the file. This means that it is the programmer's job to
 include the newline characters as part of the string if desired.
 
-Assume that we have been asked to provide a file consisting of all the squared numbers from 1 
+Assume that we have been asked to provide a file consisting of all the squared numbers from 1
 to 12.
 
-First, we will need to open the file. Afterwards, we will iterate through the numbers 1 through 
-12, and square each one of them. This new number will need to be converted to a string, and 
+First, we will need to open the file. Afterwards, we will iterate through the numbers 1 through
+12, and square each one of them. This new number will need to be converted to a string, and
 then it can be written into the file.
 
-The program below solves part of the problem. We first want to make sure that we've written the 
+The program below solves part of the problem. We first want to make sure that we've written the
 correct code to calculate the square of each number.
 
 .. activecode:: ac9_7_1
@@ -47,22 +47,22 @@ correct code to calculate the square of each number.
         square = number * number
         print(square)
 
-When we run this program, we see the lines of output on the screen. Once we are satisfied that 
-it is creating the appropriate output, the next step is to add the necessary pieces to produce 
-an output file and write the data lines to it. To start, we need to open a new output file by 
-calling the ``open`` function, ``outfile = open("squared_numbers.txt",'w')``, using the ``'w'`` 
-flag.  We can choose any file name we like. If the file does not exist, it will be created. 
-However, if the file does exist, it will be reinitialized as empty and you will lose any 
-previous contents.  
+When we run this program, we see the lines of output on the screen. Once we are satisfied that
+it is creating the appropriate output, the next step is to add the necessary pieces to produce
+an output file and write the data lines to it. To start, we need to open a new output file by
+calling the ``open`` function, ``outfile = open("squared_numbers.txt",'w')``, using the ``'w'``
+flag.  We can choose any file name we like. If the file does not exist, it will be created.
+However, if the file does exist, it will be reinitialized as empty and you will lose any
+previous contents.
 
-Once the file has been created, we just need to call the ``write`` method passing the string 
-that we wish to add to the file. In this case, the string is already being printed so we will 
-just change the ``print`` into a call to the ``write`` method. However, there is an additional 
-step to take, since the write method can only accept a string as input. We'll need to convert 
-the number to a string. Then, we just need to add one extra character to the string. The 
-newline character needs to be concatenated to the end of the line. The entire line now becomes 
-``outfile.write(str(square)+ '\n')``. The print statement automatically outputs a newline 
-character after whatever text it outputs, but the write method does not do that automatically. 
+Once the file has been created, we just need to call the ``write`` method passing the string
+that we wish to add to the file. In this case, the string is already being printed so we will
+just change the ``print`` into a call to the ``write`` method. However, there is an additional
+step to take, since the write method can only accept a string as input. We'll need to convert
+the number to a string. Then, we just need to add one extra character to the string. The
+newline character needs to be concatenated to the end of the line. The entire line now becomes
+``outfile.write(str(square)+ '\n')``. The print statement automatically outputs a newline
+character after whatever text it outputs, but the write method does not do that automatically.
 We also need to close the file when we are done.
 
 The complete program is shown below.
@@ -89,4 +89,4 @@ The complete program is shown below.
     infile = open(filename, "r")
     print(infile.read()[:10])
 
-    
+


### PR DESCRIPTION
PythonTutor does not support file reading ,so having the show in codelens button is confusing.  This removes the show in codelens button from the file examples.