### PR TITLE
Assert for tests

### DIFF
--- a/_sources/Classes/TestingClasses.rst
+++ b/_sources/Classes/TestingClasses.rst
@@ -51,22 +51,21 @@ Try adding some more tests in the code below, once you understand what's there.
             self.x = self.x + dx
             self.y = self.y + dy
 
-    import test
 
     #testing class constructor (__init__ method)
     p = Point(3, 4)
-    test.testEqual(p.y, 4)
-    test.testEqual(p.x, 3)
+    assert p.y == 4
+    assert p.x == 3
 
     #testing the distance method
     p = Point(3, 4)
-    test.testEqual(p.distanceFromOrigin(), 5.0)
+    assert p.distanceFromOrigin() == 5.0
 
     #testing the move method
     p = Point(3, 4)
     p.move(-2, 3)
-    test.testEqual(p.x, 1)
-    test.testEqual(p.y, 7)
+    assert p.x == 1
+    assert p.y == 7
 
 **Check your understanding**
 

--- a/_sources/Functions/Exercises.rst
+++ b/_sources/Functions/Exercises.rst
@@ -160,8 +160,6 @@ Exercises
             .. activecode:: answer11_14_4
                 :nocodelens:
 
-                from test import testEqual
-
                 def reverse(mystr):
                     reversed = ''
                     for char in mystr:
@@ -171,10 +169,10 @@ Exercises
                 def mirror(mystr):
                     return mystr + reverse(mystr)
 
-                testEqual(mirror('good'), 'gooddoog')
-                testEqual(mirror('Python'), 'PythonnohtyP')
-                testEqual(mirror(''), '')
-                testEqual(mirror('a'), 'aa')
+                assert mirror('good') == 'gooddoog'
+                assert mirror('Python') == 'PythonnohtyP'
+                assert mirror('') == ''
+                assert mirror('a') == 'aa'
 
         .. tab:: Discussion
 

--- a/_sources/TestCases/ChapterAssessment.rst
+++ b/_sources/TestCases/ChapterAssessment.rst
@@ -19,7 +19,7 @@ Chapter Assessment
 
    The function `mySum` is supposed to return the sum of a list of numbers (and 0 if that list is empty), but it has one or more errors in it. Use this space to write test cases to determine what errors there are. You will be using this information to answer the next set of multiple choice questions.
    ~~~~
-   import test
+
 
 
 
@@ -63,7 +63,6 @@ Chapter Assessment
 
    There are one or more errors in the class. Use this space to write test cases to determine what errors there are. You will be using this information to answer the next set of multiple choice questions.
    ~~~~
-   import test
 
 
 .. mchoice:: mc_19_4_3

--- a/_sources/TestCases/TestingConditionals.rst
+++ b/_sources/TestCases/TestingConditionals.rst
@@ -1,0 +1,42 @@
+..  Copyright (C)  Paul Resnick.  Permission is granted to copy, distribute
+    and/or modify this document under the terms of the GNU Free Documentation
+    License, Version 1.3 or any later version published by the Free Software
+    Foundation; with Invariant Sections being Forward, Prefaces, and
+    Contributor List, no Front-Cover Texts, and no Back-Cover Texts.  A copy of
+    the license is included in the section entitled "GNU Free Documentation
+    License".
+
+Testing Conditionals
+====================
+
+Ideally, you want tests that will cover both the typical execution of your program and tests for unusual things that might happen, which are called **edge cases**.
+
+If the code has conditional blocks (``if..elif..else``) then you'll want to have tests that check that the right block executes when you expect it to. For example, in the code below, z is set to the smaller of x and y, but if they are equal then we set z to 0. Our code even includes a comment to help us keep track of when we think the final code block should execute.
+
+.. code-block:: python
+
+    if x < y:
+        z = x
+    else:
+        if x > y:
+            z = y
+        else:
+            ## x must be equal to y
+            z = 0
+
+When you start to have complex conditionals, it's helpful to add comments like that, and once you do you might as well add an assert statement. If the assert ever causes an error, you'll be grateful to know right away that something has gone wrong and you'll have a good start on where to look for debugging. In this case, you'll never get an error.
+
+.. activecode:: ac19_1c_1
+
+    if x < y:
+        z = x
+    else:
+        if x > y:
+            z = y
+        else:
+            ## x must be equal to y
+            assert x==y
+            z = 0
+
+
+

--- a/_sources/TestCases/TestingConditionals.rst
+++ b/_sources/TestCases/TestingConditionals.rst
@@ -24,10 +24,12 @@ If the code has conditional blocks (``if..elif..else``) then you'll want to have
             ## x must be equal to y
             z = 0
 
-When you start to have complex conditionals, it's helpful to add comments like that, and once you do you might as well add an assert statement. If the assert ever causes an error, you'll be grateful to know right away that something has gone wrong and you'll have a good start on where to look for debugging. In this case, you'll never get an error.
+When you start to have complex conditionals, it's helpful to add comments like that, and once you do you might as well add an assert statement. If the assert ever causes an error, you'll be grateful to know right away that something has gone wrong and you'll have a good start on where to look for debugging. In this case, you'll never get an error, no matter the values of x and y.
 
 .. activecode:: ac19_1c_1
 
+    x = 3
+    y = 4
     if x < y:
         z = x
     else:

--- a/_sources/TestCases/TestingLoops.rst
+++ b/_sources/TestCases/TestingLoops.rst
@@ -42,7 +42,7 @@ But what about when ``lst`` is an empty list? Maybe we want to assert that the v
    nums = []
 
    if len(nums) == 0:
-      accum == None
+      accum = None
    else:
       accum = 0
       for w in nums:

--- a/_sources/TestCases/TestingLoops.rst
+++ b/_sources/TestCases/TestingLoops.rst
@@ -1,0 +1,52 @@
+..  Copyright (C)  Paul Resnick.  Permission is granted to copy, distribute
+    and/or modify this document under the terms of the GNU Free Documentation
+    License, Version 1.3 or any later version published by the Free Software
+    Foundation; with Invariant Sections being Forward, Prefaces, and
+    Contributor List, no Front-Cover Texts, and no Back-Cover Texts.  A copy of
+    the license is included in the section entitled "GNU Free Documentation
+    License".
+
+Testing Loops
+=============
+
+With a for loop, the edge cases might include iterating over an empty list or string, or iterating over a list with different kinds of contents.
+
+For example, suppose we have a code snippet that is supposed to accumulate the sum of all the numbers in a list, ``lst``, whose value was set sometime before this code snippet is run. If you've already learned how to define functions, you can imagine this code snippet inside a function definition.
+
+When ``lst`` is ``[1, 5, 8]``, the value at the end should be 14.
+
+.. activecode:: ac19_1d_1
+
+   nums = [1, 5, 8]
+
+   accum = 0
+   for w in nums:
+       accum = accum + w
+   assert accum == 14
+
+But what about when ``lst`` is an empty list? Maybe we want to assert that the value should be 0, in which case our current accumulation works fine. But suppose we wanted it to be some other value, perhaps the special python value ``None``. By writing an assert statement, we can be alerted that our code doesn't produce the answer we wanted...
+
+.. activecode:: ac19_1d_2
+
+   nums = []
+
+   accum = 0
+   for w in nums:
+       accum = accum + w
+   assert accum == None
+
+...and then we can fix our accumulator code
+
+.. activecode:: ac19_1d_3
+
+   nums = []
+
+   if len(nums) == 0:
+      accum == None
+   else:
+      accum = 0
+      for w in nums:
+          accum = accum + w
+   assert accum == None
+
+

--- a/_sources/TestCases/TestingOptionalParameters.rst
+++ b/_sources/TestCases/TestingOptionalParameters.rst
@@ -1,0 +1,22 @@
+..  Copyright (C)  Paul Resnick and Lauren Murphy.  Permission is granted to copy, distribute
+    and/or modify this document under the terms of the GNU Free Documentation
+    License, Version 1.3 or any later version published by the Free Software
+    Foundation; with Invariant Sections being Forward, Prefaces, and
+    Contributor List, no Front-Cover Texts, and no Back-Cover Texts.  A copy of
+    the license is included in the section entitled "GNU Free Documentation
+    License".
+
+
+Testing Optional Parameters
+===========================
+
+If a function takes an optional parameter, one of the edge cases to test for is when no parameter value is supplied
+during execution. Below are some tests for the built-in sorted function.
+
+.. activecode:: ac19_2_3
+
+
+    assert sorted([1, 7, 4]) == [1, 4, 7]
+    assert sorted([1, 7, 4], reverse=True) == [7, 4, 1]
+
+

--- a/_sources/TestCases/TestingTypes.rst
+++ b/_sources/TestCases/TestingTypes.rst
@@ -1,0 +1,50 @@
+..  Copyright (C)  Paul Resnick.  Permission is granted to copy, distribute
+    and/or modify this document under the terms of the GNU Free Documentation
+    License, Version 1.3 or any later version published by the Free Software
+    Foundation; with Invariant Sections being Forward, Prefaces, and
+    Contributor List, no Front-Cover Texts, and no Back-Cover Texts.  A copy of
+    the license is included in the section entitled "GNU Free Documentation
+    License".
+
+
+Checking Assumptions About Data Types
+=====================================
+
+Unlike some other programming languages, the python interpreter does not enforce restrictions about the data types of objects that can be bound to particular variables. For example, in java, before assigning a value to a variable, the program would include a declaration of what type of value (integer, float, Boolean, etc.) that the variable is allowed to hold. The variable ``x`` in a python program can be bound to an integer at one point and to a list at some other point in the program execution.
+
+That flexibility makes it easier to get started with programming in python. Sometimes, however, type checking could alert us that something has gone wrong in our program execution. If we are assuming at that ``x`` is a list, but it's actually an integer, then at some point later in the program execution, there will probably be an error. We can add ``assert`` statements that will cause an error to be flagged sooner rather than later, which might make it a lot easier to debug.
+
+In the code below, we explicitly state some natural assumptions about how truncated division might work in python. It turns out that the second asumption is wrong: ``9.0//5`` produces ``2.0``, a floating point value!
+
+.. activecode:: ac19_1b_1
+
+    assert type(9//5) == int
+    assert type(9.0//5) == int
+
+
+In the code below, ``lst`` is bound to a list object. In python, not all the elements of a list have to be of the same type. We can check that they all have the same type and get an error if they are not. Notice that with ``lst2``, one of the assertions fails.
+
+.. activecode:: ac19_1b_2
+
+    lst = ['a', 'b', 'c']
+
+    first_type = type(lst[0])
+    for item in lst:
+        assert type(item) == first_type
+
+    lst2 = ['a', 'b', 'c', 17]
+    first_type = type(lst2[0])
+    for item in lst2:
+        assert type(item) == first_type
+
+
+Checking Other Assumptions
+==========================
+
+We can also check other assumptions about the values of variables, in addition to their types. For example, we could check that a list has fewer than 10 items.
+
+.. activecode:: ac19_1b_3
+
+    lst = ['a', 'b', 'c']
+
+    assert len(lst) < 10

--- a/_sources/TestCases/Testingfunctions.rst
+++ b/_sources/TestCases/Testingfunctions.rst
@@ -1,5 +1,4 @@
-..  Copyright (C)  Brad Miller, David Ranum, Jeffrey Elkner, Peter Wentworth, Allen B. Downey, Chris
-    Meyers, and Dario Mitchell.  Permission is granted to copy, distribute
+..  Copyright (C)  Paul Resnick and Lauren Murphy.  Permission is granted to copy, distribute
     and/or modify this document under the terms of the GNU Free Documentation
     License, Version 1.3 or any later version published by the Free Software
     Foundation; with Invariant Sections being Forward, Prefaces, and
@@ -32,8 +31,8 @@ Return Value Tests
 Testing whether a function returns the correct value is the easiest test case to define. You simply check whether the 
 result of invoking the function on a particular input produces the particular output that you expect. If ``f`` is your 
 function, and you think that it should transform inputs ``x`` and ``y`` into output ``z``, then you could write a test as 
-``test.testEqual(f(x, y), z)``. Or, to give a more concrete example, if you have a function ``square``, you could have 
-a test case ``test.testEqual(square(3), 9)``. Call this a **return value test**.
+``assert f(x, y) == z``. Or, to give a more concrete example, if you have a function ``square``, you could have
+a test case ``assert square(3) ==  9``. Call this a **return value test**.
 
 Because each test checks whether a function works properly on specific inputs, the test cases will never be complete: in 
 principle, a function might work properly on all the inputs that are tested in the test cases, but still not work 
@@ -61,9 +60,7 @@ Try adding one or two more test cases for the square function in the code below,
     def square(x):
         return x*x
 
-    import test
-
-    test.testEqual(square(3), 9)
+    assert square(3) == 9
 
 
 Side Effect Tests
@@ -90,44 +87,14 @@ answers ourselves.
             if c in counts_d:
                 counts_d[c] = counts_d[c] + 1
 
-    import test
 
     counts = {'a': 3, 'b': 2}
     update_counts("aaab", counts)
     # 3 more occurrences of a, so 6 in all
-    test.testEqual(counts['a'], 6)
+    assert counts['a'] == 6
     # 1 more occurrence of b, so 3 in all
-    test.testEqual(counts['b'], 3)
+    assert counts['b'] == 3
 
-
-Testing Conditionals and Loops
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If the code has a conditional execution, or a for loop, then you'll want to include test cases that exercise different 
-possible paths through the code. For example, if there is a for loop, edge cases would include iteration through an empty 
-sequence or a sequence with just one item. With a conditional, you would want different inputs that cause the if and else 
-clauses to execute.
-
-If you were writing tests on a function that takes any list as input and returns a value that is a computation on that 
-input list, you might test the function's return value when it is invoked on an empty list, a list with only one value, a 
-list with an element that is a list itself, a list that has many elements...
-
-Try adding those some of those tests in the code window above, for the update_counts function. What if you start with an 
-empty counts dictionary? What if the string passed to update_counts is empty? What if the string includes letters that 
-aren't in the dictionary yet?
-
-Testing Optional Parameters
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-If a function takes an optional parameter, one of the edge cases to test for is when no parameter value is supplied 
-during execution. Below are some tests for the built-in sorted function.
-
-.. activecode:: ac19_2_3
-
-    import test
-
-    test.testEqual(sorted([1, 7, 4]), [1, 4, 7])
-    test.testEqual(sorted([1, 7, 4], reverse=True), [7, 4, 1])
 
 
 .. mchoice:: question19_2_1
@@ -138,3 +105,16 @@ during execution. Below are some tests for the built-in sorted function.
    :feedback_b: The tests should cover as many edge cases as you can think of, but there's always a possibility that the function does badly on some input that you didn't include as a test case.
 
    If you write a complete set of tests and a function passes all the tests, you can be sure that it's working correctly.
+
+.. mchoice:: question19_1_3
+    :answer_a: assert blanked('under', 'du', 'u_d__') == True
+    :answer_b: assert blanked('under', 'u_d__') == 'du'
+    :answer_c: assert blanked('under', 'du') == 'u_d__'
+    :correct: c
+    :feedback_a: blanked only takes two inputs; this provides three inputs to the blanked function
+    :feedback_b: The second argument to the blanked function should be the letters that have been guessed, not the blanked version of the word
+    :feedback_c: This checks whether the value returned from the blanked function is 'u_d__'.
+    :practice: T
+
+    For the hangman game, the blanked function takes a word and some letters that have been guessed, and returns a version of the word with _ for all the letters that haven't been guessed. Which of the following is the correct way to write a test to check that 'under' will be blanked as ``'u_d__'`` when the user has guessed letters d and u so far?
+

--- a/_sources/TestCases/WPProgramDevelopment.rst
+++ b/_sources/TestCases/WPProgramDevelopment.rst
@@ -52,36 +52,34 @@ Obviously, this version of the function doesn't compute distances; it always
 returns None. But it is syntactically correct, and it will run, which means
 that we can test it before we make it more complicated.
 
-We import the test module to enable us to write a unit test for the function. The distance between any point and itself should be 0.
+The distance between any point and itself should be 0.
 
 .. activecode:: ac400_1_1
-    
-    import test
+
     def distance(x1, y1, x2, y2):
         return None
 
-    test.testEqual(distance(1, 2, 1, 2), 0)
+    assert distance(1, 2, 1, 2) == 0
 
-The ``testEqual`` function from the test module calls the distance function with sample inputs: (1,2, 1,2).
+We call the distance function with sample inputs: (1,2, 1,2).
 The first 1,2 are the coordinates of the first point and the second 1,2 are the coordinates of the second point.
-What is the distance between these two points? Zero. ``testEqual`` compares what is returned by the distance function
-and the None that is returned.
+What is the distance between these two points? Zero.
 
 It's not returning the correct answer, so we don't pass the test. Let's fix that.
 
 .. activecode:: ac400_1_2
 
-    import test
     def distance(x1, y1, x2, y2):
         return 0.0
 
-    test.testEqual(distance(1, 2, 1, 2), 0)
+    assert distance(1, 2, 1, 2) == 0
+
 
 Now we pass the test. But really, that's not a sufficient test.
 
 .. admonition:: Extend the program ...
 
-   On line 6, write another unit test. Use (1,2, 4,6) as the parameters to the distance function. How far apart are these two points? Use that value (instead of 0) as the correct answer for this unit test.
+   On line 6, write another unit test (assert statement). Use (1,2, 4,6) as the parameters to the distance function. How far apart are these two points? Use that value (instead of 0) as the correct answer for this unit test.
 
    On line 7, write another unit test. Use (0,0, 1,1) as the parameters to the distance function. How far apart are these two points? Use that value as the correct answer for this unit test.
 
@@ -95,14 +93,12 @@ For the second test the horizontal distance equals 3 and the vertical distance e
 
 .. activecode:: ac400_1_3
 
-    import test
     def distance(x1, y1, x2, y2):
         return 0
 
-    test.testEqual(distance(1,2, 1,2), 0)
-    test.testEqual(distance(1,2, 4,6), 5)
-    test.testEqual(distance(0,0, 1,1), 2**0.5)
-
+    assert distance(1, 2, 1, 2) == 0
+    assert distance(1,2, 4,6) == 5
+    assert distance(0,0, 1,1) = 2**0.5
 
 
 The first test passes but the others fail since the distance function does not yet contain all the necessary steps.
@@ -140,8 +136,7 @@ we compute and return the result.
 .. index:: testing, unit test
 
 .. activecode:: ac400_1_4
-    
-    import test
+
     def distance(x1, y1, x2, y2):
         dx = x2 - x1
         dy = y2 - y1
@@ -149,9 +144,9 @@ we compute and return the result.
         result = dsquared**0.5
         return result
 
-    test.testEqual(distance(1,2, 1,2), 0)
-    test.testEqual(distance(1,2, 4,6), 5)
-    test.testEqual(distance(0,0, 1,1), 2**0.5)
+    assert distance(1, 2, 1, 2) == 0
+    assert distance(1,2, 4,6) == 5
+    assert distance(0,0, 1,1) = 2**0.5
 
 
 ..     test.testEqual(distance(0,0, 1,1), 1.41)

--- a/_sources/TestCases/intro-TestCases.rst
+++ b/_sources/TestCases/intro-TestCases.rst
@@ -1,5 +1,4 @@
-..  Copyright (C)  Brad Miller, David Ranum, Jeffrey Elkner, Peter Wentworth, Allen B. Downey, Chris
-    Meyers, and Dario Mitchell.  Permission is granted to copy, distribute
+..  Copyright (C)  Paul Resnick and Lauren Murphy.  Permission is granted to copy, distribute
     and/or modify this document under the terms of the GNU Free Documentation
     License, Version 1.3 or any later version published by the Free Software
     Foundation; with Invariant Sections being Forward, Prefaces, and
@@ -20,52 +19,65 @@ A **test case** expresses requirements for a program, in a way that can be check
 asserts something about the state of the program at a particular point in its execution.
 
 We have previously suggested that it's a good idea to first write down comments about what your code is supposed to do, 
-before actually writing the code. It is an even better idea to write down some test cases before writing a program. For 
-example, before writing a function, write a few test cases that check that it returns an object of the right type and 
-that it returns the correct values when invoked on particular inputs.
+before actually writing the code. It is an even better idea to write down some test cases before writing a program.
 
 There are several reasons why it's a good habit to write test cases.
 
 * Before we write code, we have in mind what it *should* do, but those thoughts may be a little vague. Writing down test cases forces us to be more concrete about what should happen.
 * As we write the code, the test cases can provide automated feedback. You've actually been the beneficiary of such automated feedback via test cases throughout this book in some of the activecode windows and almost all of the exercises. We wrote the code for those test cases but kept it hidden, so as not to confuse you and also to avoid giving away the answers. You can get some of the same benefit from writing your own test cases.
-* In larger software projects, the set of test cases, called unit tests, can be run every time a change is made to the code base. This can help to identify situations where a change in code in one place breaks the correct operation of some other code. We won't see that advantage of tests cases in this textbook, but keep in mind that this introduction to test cases is setting the stage for an essential software engineering practice if you are participating in a larger software development project.
+* In larger software projects, the set of test cases can be run every time a change is made to the code base. **Unit tests** check that small bits of code are correctly implemented. **Functional tests** check that larger chunks of code work correctly. Running the tests can help to identify situations where a change in code in one place breaks the correct operation of some other code. We won't see that advantage of test cases in this textbook, but keep in mind that this introduction to test cases is setting the stage for an essential software engineering practice if you are participating in a larger software development project.
 
-Now it's time to learn how to write code for test cases, or **unit tests**. To write one, we must know what we *expect* some value to be at a particular point in the program's execution. For example, we need to specify what the correct result would be when calling the function with a specific input.
+Now it's time to learn how to write code for test cases.
 
-.. activecode:: ac19_1_1
+Python provides a statement called ``assert``. Following the word assert there will be a python expression. If that expression evaluates to the Boolean ``False``, then the interpreter will raise a runtime error. If the expression evaluates to ``True``, then nothing happens and the execution goes on to the next line of code.
 
-    def square(x):
-        '''raise x to the second power'''
-        return x * x
-    
-    import test
-    print('testing square function')
-    test.testEqual(square(10), 100)
+Why would you ever want to write a line of code that can never compute anything useful for you, but sometimes causes a runtime error? For all the reasons we described above about the value of automated tests. You want a test that will alert that you that some condition you assumed was true is not in fact true. It's much better to be alerted to that fact right away than to have some unexpected result much later in your program execution, which you will have trouble tracing to the place where you had an error in your code.
 
+Why doesn't ``assert`` print out something saying that the test passed? The reason is that you don't want to clutter up your output window with the results of automated tests that pass. You just want to know when one of your tests fails. In larger projects, other testing harnesses are used instead of ``assert``, such as the python ``unittest`` module. Those provide some output summarizing tests that have passed as well as those that failed. In this textbook, we will just use simple ``assert`` statements for automated tests.
 
-``testEqual`` (from the ``test`` module) is a function that allows us to perform a unit test. It takes two parameters. In the example above, the first is a call to the function we want to test (``square`` in this example) with a particular input (10 in this example). The second is the correct result that should be produced (100 in this example). ``test.testEqual`` compares the two values and displays a message about whether the unit test passes or fails: pass if the two values are equal, fail if not.
-
-.. admonition:: Extend the program ...
-
-   On line 8, write another unit test (that should pass) for the ``square`` function.
+To write a test, we must know what we *expect* some value to be at a particular point in the program's execution. In the rest of the chapter, we'll see some examples of ``assert`` statements and ideas for what kinds of assertions one might want to add in one's programs.
 
 .. note::
-   The ``test`` module is not a standard Python module. Instead, there are other more powerful and more modern modules, such as one called ``unittest`` which will be taught in more advanced courses. However, the ``test`` module offers a simple introduction to testing that is appropriate at this stage in the interactive text.
+    A note to instructors: this chapter is deliberately structured so that you can introduce testing early in the course if you want to. You will need to cover chapter 8, on Conditionals, before starting this chapter, because that chapter covers Booleans. The subchapters on testing types and testing conditionals can be covered right after that. The subchapter on testing functions can be delayed until after you have covered function definition.
+
 
 **Check your understanding**
 
 .. mchoice:: question19_1_1
-   :answer_a: True
-   :answer_b: False
-   :answer_c: It depends
-   :correct: b
-   :feedback_a: A message is printed out, but the program does not stop executing
-   :feedback_b: A message is printed out, but the program does not stop executing
-   :feedback_c: A message is printed out, but the program does not stop executing
+   :answer_a: A runtime error will occur
+   :answer_b: A message is printed out saying that the test failed.
+   :answer_c: x will get the value that y currently has
+   :answer_d: Nothing will happen
+   :answer_e: A message is printed out saying that the test passed.
+   :correct: a
+   :feedback_a: The expression ``x==y`` evaluates to ``False``, so a runtime error will occur
+   :feedback_b: If the assertion fails, a runtime error will occur
+   :feedback_c: ``x==y`` is a Boolean expression, not an assignment statement
+   :feedback_d: The expression ``x==y`` evaluates to ``False``
+   :feedback_e: When an assertion test passes, no message is printed. In this case, the assertion test fails.
    :practice: T
 
-   When ``test.testEqual()`` is passed two values that are not the same, it generates an error and stops execution of the program.
- 
+   When ``assert x==y`` is executed and x and y have different values, what will happen?
+
+
+.. mchoice:: question19_1_1b
+   :answer_a: A runtime error will occur
+   :answer_b: A message is printed out saying that the test failed.
+   :answer_c: x will get the value that y currently has
+   :answer_d: Nothing will happen
+   :answer_e: A message is printed out saying that the test passed.
+   :correct: d
+   :feedback_a: The expression ``x==y`` evaluates to ``True``
+   :feedback_b: The expression ``x==y`` evaluates to ``True``
+   :feedback_c: ``x==y`` is a Boolean expression, not an assignment statement
+   :feedback_d: The expression ``x==y`` evaluates to ``True``
+   :feedback_e: When an assertion test passes, no message is printed.
+   :practice: T
+
+   When ``assert x==y`` is executed and x and y have the same values, what will happen?
+
+
+
 .. mchoice:: question19_1_2
    :answer_a: True
    :answer_b: False
@@ -77,26 +89,3 @@ Now it's time to learn how to write code for test cases, or **unit tests**. To w
    Test cases are a waste of time, because the python interpreter will give an error
    message when the program runs incorrectly, and that's all you need for debugging.
 
-.. mchoice:: question19_1_3
-    :answer_a: test.testEqual(blanked('under', 'du', 'u_d__'))
-    :answer_b: test.testEqual(blanked('under', 'u_d__'), 'du')
-    :answer_c: test.testEqual(blanked('under', 'du'), 'u_d__')
-    :correct: c
-    :feedback_a: blanked only takes two inputs; this provides three inputs to the blanked function
-    :feedback_b: The second argument to the blanked function should be the letters that have been guessed, not the blanked version of the word
-    :feedback_c: This checks whether the value returned from the blanked function is 'u_d__'.
-    :practice: T
-
-    For the hangman game blanked function, which of the following is the correct way to write a test to check that 'under' will be blanked as ``'u_d__'`` when the user has guessed letters d and u so far?
-
-    .. code-block:: python
-
-        def blanked(word, revealed_letters):
-            return word
-
-        import test
-
-        test.testEqual(blanked('hello', 'elj'), "_ell_")
-        test.testEqual(blanked('hello', ''), '_____')
-        test.testEqual(blanked('ground', 'rn'), '_r__n_')
-        test.testEqual(blanked('almost', 'vrnalmqpost'), 'almost')

--- a/_sources/TestCases/intro-TestCases.rst
+++ b/_sources/TestCases/intro-TestCases.rst
@@ -29,7 +29,11 @@ There are several reasons why it's a good habit to write test cases.
 
 Now it's time to learn how to write code for test cases.
 
-Python provides a statement called ``assert``. Following the word assert there will be a python expression. If that expression evaluates to the Boolean ``False``, then the interpreter will raise a runtime error. If the expression evaluates to ``True``, then nothing happens and the execution goes on to the next line of code.
+Python provides a statement called ``assert``.
+
+- Following the word assert there will be a python expression.
+- If that expression evaluates to the Boolean ``False``, then the interpreter will raise a runtime error.
+- If the expression evaluates to ``True``, then nothing happens and the execution goes on to the next line of code.
 
 Why would you ever want to write a line of code that can never compute anything useful for you, but sometimes causes a runtime error? For all the reasons we described above about the value of automated tests. You want a test that will alert that you that some condition you assumed was true is not in fact true. It's much better to be alerted to that fact right away than to have some unexpected result much later in your program execution, which you will have trouble tracing to the place where you had an error in your code.
 

--- a/_sources/TestCases/toctree.rst
+++ b/_sources/TestCases/toctree.rst
@@ -6,7 +6,11 @@ Test Cases
    :maxdepth: 3
 
    intro-TestCases.rst
+   TestingTypes.rst
+   TestingConditionals.rst
+   TestingLoops.rst
    Testingfunctions.rst
+   TestingOptionalParameters.rst
    WPProgramDevelopment.rst
    Glossary.rst
    ChapterAssessment.rst


### PR DESCRIPTION
This is a rewrite of the Testing chapter, and also other places in the text where test.testEqual was used, substituting assert.