### PR TITLE
Remove link in read me file that returns empty image

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,6 @@ there is a unique feature called 'codelens' that allows you to control the
 flow of execution in order to gain a better understanding of how the program
 works.
 
-.. image:: http://bnmnetp.me:8088/buildStatus/icon?job=thinkcspyBuild
-
 Getting Started
 ===============
 


### PR DESCRIPTION
## Problem/Motivation
The read me file contains a link to an image that no longer works from an outdated jenkins instance. 

## Proposed resolution
Remove the link

## Remaining tasks
Figure out what the link was 'pointed at'  and decide either to add it back in or not add it back in.  If you want me to help do this please provide some guidance 