### PR TITLE
Update index.rst

### DIFF
--- a/_sources/index.rst
+++ b/_sources/index.rst
@@ -34,7 +34,8 @@
    * ACM-SIGCSE for the special projects grant that funded our student Isaac Dontje Lindell for the summer of 2013.
    * NSF
 
-   The Runestone Interactive tools are open source and we encourage you to contact us, or grab a copy from GitHub if you would like to use them to write your own resources.
+   The Runestone Interactive tools are open source and we encourage you to contact us, or grab a copy from GitHub <https://github.com/RunestoneInteractive> if you would like to use them to write your own resources.
+   
 
    We also `welcome your support <https://runestone.academy/runestone/default/donate/10>`_ to help keep Runestone growing.
 


### PR DESCRIPTION
## Problem/Motivation
I noticed in the 'About this Course' tab on the fopp site:
https://runestone.academy/runestone/books/published/fopp/index.html

## Proposed Resolution
Added Github link pointing at the primary RunestoneInteractive in the 'About this Project' to make navigation to GitHub easy.