### PR TITLE
Minor word edits

### DIFF
--- a/_sources/Inheritance/inheritVarsAndMethods.rst
+++ b/_sources/Inheritance/inheritVarsAndMethods.rst
@@ -160,7 +160,7 @@ So what is happening in the Python interpreter when you write programs with clas
 1. First, it checks for an instance variable or an instance method by the name it's looking for.
 2. If an instance variable or method by that name is not found, it checks for a class variable. (See the :ref:`previous chapter <class_and_instance_vars>` for an explanation of the difference between **instance variables** and **class variables**.)
 3. If no class variable is found, it looks for a class variable in the parent class.
-4. If no class variable is found _there_, the interpreter looks for a class variable in THAT class's parent, if it exists -- the "grandparent" class.
+4. If no class variable is found, the interpreter looks for a class variable in THAT class's parent (the "grandparent" class).
 5. This process goes on until the last ancestor is reached, at which point Python will signal an error.
 
 Let's look at this with respect to some code.


### PR DESCRIPTION
## Problem/Motivation
Under the section: How the interpreter looks up attributes
The word 'there' was underlined, but didn't render properly in the browser line 163. 
The Grandparent class referencing on line 163 was a little awkward.

## Proposed resolution
Remove the word 'there' and change the way grandparent class is referenced.

## Remaining tasks
Decide if these changes make sense.