### PR TITLE
Clarifying instructions

### DIFF
--- a/_sources/Sorting/ChapterAssessment.rst
+++ b/_sources/Sorting/ChapterAssessment.rst
@@ -195,7 +195,7 @@ Chapter Assessment
    :practice: T
    :topics: Sorting/Optionalkeyparameter
 
-   Create a function called ``last_four`` that takes in an ID number and returns the last four digits. For example, the number 17573005 should return 3005. Then, use this function to sort the list of ids stored in the variable, ``ids``, from lowest to highest. Save this sorted list in the variable, ``sorted_ids``. Hint: Remember that only strings can be indexed, so conversions may be needed.
+   Create a function called ``last_four`` that takes in a single ID number and returns the last four digits. For example, the number 17573005 should return 3005. Then, use the resulting function to sort the list of ids stored in the variable, ``ids``, from lowest to highest. Save this sorted list in the variable, ``sorted_ids``. Hint: Remember that only strings can be indexed, so conversions may be needed.
    ~~~~
 
    def last_four(x):


### PR DESCRIPTION
Proposing ideas to address two common misinterpretations that students have with this problem:

(1) that last_four should take in a list of numbers (rather than a single number) and return a list of the last four digits of each number. E.g. last_four takes in [17573005, 17572342, 17579000] and returns [3005, 2342, 9000]

(2) that sorting the list of ids should take place within the definition of last_four (rather than outside of last_four)

Although the original instructions seem clear, it still might be a good idea to add more clarifying language to prevent future confusion/errors