### PR TITLE
Cast `range()` call to a list

### DIFF
--- a/_sources/Iteration/week2a2.rst
+++ b/_sources/Iteration/week2a2.rst
@@ -189,6 +189,6 @@ Chapter Assessment
    class myTests(TestCaseGui):
 
       def testOne(self):
-         self.assertEqual(nums, range(68), "Testing that nums is a list that contains the correct elements.")
+         self.assertEqual(nums, list(range(68)), "Testing that nums is a list that contains the correct elements.")
 
    myTests().main()


### PR DESCRIPTION
Now that Skulpt actually produces range objects, the call in this test needs to be cast to a list.